### PR TITLE
Add OAuth2 bearer token authentication option

### DIFF
--- a/pingfederate/config/Config.go
+++ b/pingfederate/config/Config.go
@@ -13,6 +13,7 @@ type Config struct {
 	LogDebug          *bool
 	MaskAuthorization *bool
 	Endpoint          *string
+	Token             *string
 
 	// The HTTP client to use when sending requests. Defaults to
 	// `http.DefaultClient`.
@@ -38,6 +39,11 @@ func (c *Config) WithPassword(password string) *Config {
 
 func (c *Config) WithUsername(username string) *Config {
 	c.Username = pingfederate.String(username)
+	return c
+}
+
+func (c *Config) WithToken(token string) *Config {
+	c.Token = pingfederate.String(token)
 	return c
 }
 

--- a/pingfederate/request/request.go
+++ b/pingfederate/request/request.go
@@ -80,7 +80,11 @@ func New(cfg config.Config, clientInfo metadata.ClientInfo, operation *Operation
 
 	httpReq, _ := http.NewRequest(method, "", buf)
 
-	httpReq.SetBasicAuth(*cfg.Username, *cfg.Password)
+	if cfg.Token != nil {
+		httpReq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", *cfg.Token))
+	} else {
+		httpReq.SetBasicAuth(*cfg.Username, *cfg.Password)
+	}
 	httpReq.Header.Add("X-Xsrf-Header", "pingfederate")
 	httpReq.Header.Add("User-Agent", fmt.Sprintf("%s/%s (%s; %s; %s)", pingfederate.SDKName, pingfederate.SDKVersion, runtime.Version(), runtime.GOOS, runtime.GOARCH))
 


### PR DESCRIPTION
As documented here: https://docs.pingidentity.com/bundle/pingfederate-102/page/vnd1564003026634.html,
PingFederate supports 5 different authentication schemes for the administrative REST API. 

The pull request adds the option of authenticating using an OAuth2 bearer token.

No tests are provided since OAuth2 token authentication requires substantial configuration of a PingFederate instance to test against. However, these changes have been used successfully in our project to authenticate with PingFederate.